### PR TITLE
get taskEnd reason

### DIFF
--- a/pyspark_spy/classes.py
+++ b/pyspark_spy/classes.py
@@ -37,6 +37,18 @@ class JobEndEvent(JavaClass, NamedTuple('JobEndEvent', [
             jobResult=jobj.jobResult().toString()
         )
 
+class TaskEndEvent(JavaClass, NamedTuple('TaskEndEvent', [
+    ('reason', str)
+])):
+    @classmethod
+    def try_convert(cls, jobj):
+        """
+        :rtype:  JobEndEvent
+        """
+        return cls(
+            reason=jobj.reason().toString(),
+        )
+
 
 class OutputMetrics(JavaClass, NamedTuple('OutputMetrics', [
     ('bytesWritten', int),

--- a/pyspark_spy/interface.py
+++ b/pyspark_spy/interface.py
@@ -3,58 +3,78 @@ class SparkListenerInterface(object):
     """
     SparkListener python interface.
 
-    https://spark.apache.org/docs/2.3.1/api/java/org/apache/spark/scheduler/SparkListener.html
+    https://spark.apache.org/docs/3.2.1/api/java/org/apache/spark/scheduler/SparkListener.html
     """
 
     def onApplicationEnd(self, applicationEnd):
         pass
-
     def onApplicationStart(self, applicationStart):
         pass
-
+    def onBlockManagerAdded(self, blockManagerAdded):
+        pass
     def onBlockManagerRemoved(self, blockManagerRemoved):
         pass
-
     def onBlockUpdated(self, blockUpdated):
         pass
-
     def onEnvironmentUpdate(self, environmentUpdate):
         pass
-
     def onExecutorAdded(self, executorAdded):
         pass
-
+    def onExecutorBlacklisted(self, executorBlacklisted):
+        pass
+    def onExecutorBlacklistedForStage(self, executorBlacklistedForStage):
+        pass
+    def onExecutorExcluded(self, executorExcluded):
+        pass
+    def onExecutorExcludedForStage(self, executorExcludedForStage):
+        pass
     def onExecutorMetricsUpdate(self, executorMetricsUpdate):
         pass
-
     def onExecutorRemoved(self, executorRemoved):
         pass
-
+    def onExecutorUnblacklisted(self, executorUnblacklisted):
+        pass
+    def onExecutorUnexcluded(self, executorUnexcluded):
+        pass
     def onJobEnd(self, jobEnd):
         pass
-
     def onJobStart(self, jobStart):
         pass
-
+    def onNodeBlacklisted(self, nodeBlacklisted):
+        pass
+    def onNodeBlacklistedForStage(self, nodeBlacklistedForStage):
+        pass
+    def onNodeExcluded(self, nodeExcluded):
+        pass
+    def onNodeExcludedForStage(self, nodeExcludedForStage):
+        pass
+    def onNodeUnblacklisted(self, nodeUnblacklisted):
+        pass
+    def onNodeUnexcluded(self, nodeUnexcluded):
+        pass
     def onOtherEvent(self, event):
         pass
-
+    def onResourceProfileAdded(self, resourceProfileAdded):
+        pass
+    def onSpeculativeTaskSubmitted(self, speculativeTaskSubmitted):
+        pass
     def onStageCompleted(self, stageCompleted):
         pass
-
+    def onStageExecutorMetrics(self, stageExecutorMetrics):
+        pass
     def onStageSubmitted(self, stageSubmitted):
         pass
-
     def onTaskEnd(self, taskEnd):
         pass
-
     def onTaskGettingResult(self, taskGettingResult):
         pass
-
     def onTaskStart(self, taskStart):
         pass
-
     def onUnpersistRDD(self, unpersistRDD):
+        pass
+    def onUnschedulableTaskSetAdded(self, unschedulableTaskSetAdded):
+        pass
+    def onUnschedulableTaskSetRemoved(self, unschedulableTaskSetRemoved):
         pass
 
     class Java:

--- a/pyspark_spy/listeners.py
+++ b/pyspark_spy/listeners.py
@@ -3,6 +3,7 @@ import logging
 from typing import List
 
 from pyspark import SparkContext
+from pyspark.java_gateway import ensure_callback_server_started
 
 from pyspark_spy.interface import SparkListener
 from pyspark_spy.classes import JobEndEvent, StageCompletedEvent, OutputMetrics, InputMetrics, TaskEndEvent
@@ -38,6 +39,10 @@ class PersistingSparkListener(SparkListener):
     @property
     def stageCompleted(self) -> List[StageCompletedEvent]:
         return self.python_events['stageCompleted']
+
+    @property
+    def taskEnd(self) -> List[TaskEndEvent]:
+        return self.python_events['taskEnd']
 
     def stage_output_metrics_aggregate(self) -> OutputMetrics:
         # noinspection PyArgumentList
@@ -104,10 +109,7 @@ class StdoutSparkListener(LoggingSparkListener):
 
 
 def register_listener(sc: SparkContext, *listeners: SparkListener):
-    callback_server_started = sc._gateway.start_callback_server()
-    if callback_server_started:
-        logger.debug('Callback server started')
+    ensure_callback_server_started(gw = sc._gateway)
 
     for listener in listeners:
         sc._jsc.sc().addSparkListener(listener)
-

--- a/pyspark_spy/listeners.py
+++ b/pyspark_spy/listeners.py
@@ -5,7 +5,7 @@ from typing import List
 from pyspark import SparkContext
 
 from pyspark_spy.interface import SparkListener
-from pyspark_spy.classes import JobEndEvent, StageCompletedEvent, OutputMetrics, InputMetrics
+from pyspark_spy.classes import JobEndEvent, StageCompletedEvent, OutputMetrics, InputMetrics, TaskEndEvent
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +26,8 @@ class PersistingSparkListener(SparkListener):
     def from_java_event(self, event_name, java_event):
         if event_name == 'jobEnd':
             return JobEndEvent.from_java(java_event)
+        if event_name == 'taskEnd':
+            return TaskEndEvent.from_java(java_event)
         elif event_name == 'stageCompleted':
             return StageCompletedEvent.from_java(java_event)
 
@@ -108,3 +110,4 @@ def register_listener(sc: SparkContext, *listeners: SparkListener):
 
     for listener in listeners:
         sc._jsc.sc().addSparkListener(listener)
+


### PR DESCRIPTION
Test code to get taskEndEvent at python side. Add necessary code to make it runnable.

An example:
```
from pprint import pprint
import pyspark_spy
from pyspark.sql import SparkSession

from SparkListener import TaskEndListener
spark = SparkSession.builder.appName(
        "...").getOrCreate()

try:
    listener = pyspark_spy.PersistingSparkListener()
    pyspark_spy.register_listener(spark.sparkContext, listener)
    df = spark.read.parquet('...')
    df.count()
    # spark.sparkContext.range(1,100).count()
    # pprint(listener.java_events['taskEnd'])
    pprint(listener.python_events['taskEnd'])
    taskEndEventList = listener.python_events['taskEnd']
    status = taskEndEventList[0]
    # type(status.reason) : 'str'
    print(status.reason)

finally:
    spark.sparkContext._jsc.sc().removeSparkListener(listener)
    # spark.sparkContext._gateway.shutdown_callback_server()
    spark.stop()
```

result:
```
[TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success'),
 TaskEndEvent(reason='Success')]
Success
```